### PR TITLE
Fix broken link in decode raw transaction

### DIFF
--- a/_api_docs/core_decode_raw_transaction.md
+++ b/_api_docs/core_decode_raw_transaction.md
@@ -12,7 +12,7 @@ Note: This method accepts both a signed or an unsigned raw transaction and will 
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| transaction | string | Yes | The encoded transaction, as returned by [Create Raw Transaction](#create-raw-transaction) |
+| transaction | string | Yes | The encoded transaction, as returned by [Create Raw Transaction](https://projectixian.github.io/api_docs/core_create_raw_transaction.html) |
 
 
 ### Output:


### PR DESCRIPTION
Followed link formatting from [create raw tx](https://github.com/icook/projectixian.github.io/blob/c29b6a9f75f7019bbe7ce5788d2693ffccf8db49/_api_docs/core_create_raw_transaction.md#L10), hope that works.